### PR TITLE
feat(ghostty): add Ghostty theme configuration

### DIFF
--- a/ghostty.conf
+++ b/ghostty.conf
@@ -1,0 +1,27 @@
+# primary
+background = #000000
+foreground = #e6d9db
+cursor-color = #c3b7b8
+cursor-text = #2c2525
+selection-background = #403e41
+selection-foreground = #e6d9db
+
+# normal colors
+palette = 0=#333333
+palette = 1=#D35F5F
+palette = 2=#FFC107
+palette = 3=#b91c1c
+palette = 4=#e68e0d
+palette = 5=#D35F5F
+palette = 6=#bebebe
+palette = 7=#bebebe
+
+# bright colors
+palette = 8=#8a8a8d
+palette = 9=#B91C1C
+palette = 10=#FFC107
+palette = 11=#b90a0a
+palette = 12=#f59e0b
+palette = 13=#B91C1C
+palette = 14=#eaeaea
+palette = 15=#ffffff


### PR DESCRIPTION
This pr adds `ghostty.conf` providing Ghostty support for the Omarchy Felix theme.

What's included:
- `ghostty.conf` with background/foreground, cursor colors, selection colors, and the full 16-color palette matching the existing theme.

No other settings included (font/padding/decoration) to keep this file theme-only.

<img width="1056" height="426" alt="image" src="https://github.com/user-attachments/assets/9b979f5c-2c46-40b8-8924-5f9cd25f0384" />
