### PR TITLE
Fix: Replace Yaru-black with valid Yaru icon theme.

### DIFF
--- a/icons.theme
+++ b/icons.theme
@@ -1,1 +1,1 @@
-Yaru-black
+Yaru-dark\

--- a/icons.theme
+++ b/icons.theme
@@ -1,1 +1,1 @@
-Yaru-dark\
+Yaru-dark


### PR DESCRIPTION
The theme currently references `Yaru-black` in `icons.theme`, but this icon theme does not exist in the upstream Yaru icon set.

This causes media skip icons (next/previous) to fall back on placeholders.
Changing the reference to `Yaru-dark` restores the correct media OSD icons.